### PR TITLE
Try to fix examples path for build action

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -46,7 +46,7 @@ jobs:
           GOOGLE_CALENDAR_ID: ${{ secrets.GOOGLE_CALENDAR_ID }}
           GOOGLE_CALENDAR_API_KEY: ${{ secrets.GOOGLE_CALENDAR_API_KEY }}
         with:
-          run: make -C docs
+          run: make docs
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -13,14 +13,16 @@ jobs:
     steps:
       - name: Clone docs repo
         uses: actions/checkout@v3
-        with:
-          path: docs
-
+        
       - name: Clone main repo
         uses: actions/checkout@v3
         with:
           path: napari
           repository: napari/napari
+      
+      - name: Copy examples to docs folder
+        run: |
+          cp -R napari/examples ..
 
       - uses: actions/setup-python@v2
         with:

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -22,7 +22,7 @@ jobs:
       
       - name: Copy examples to docs folder
         run: |
-          cp -R napari/examples ..
+          cp -R napari/examples .
 
       - uses: actions/setup-python@v2
         with:
@@ -46,7 +46,7 @@ jobs:
           GOOGLE_CALENDAR_ID: ${{ secrets.GOOGLE_CALENDAR_ID }}
           GOOGLE_CALENDAR_API_KEY: ${{ secrets.GOOGLE_CALENDAR_API_KEY }}
         with:
-          run: make -C docs/ docs
+          run: make -C docs
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -52,4 +52,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: docs
-          path: docs/docs/_build
+          path: docs/_build

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -191,7 +191,7 @@ def reset_napari_theme(gallery_conf, fname):
 
 
 sphinx_gallery_conf = {
-    'examples_dirs': '../../napari/examples',  # path to your example scripts
+    'examples_dirs': 'napari/examples',  # path to your example scripts
     'gallery_dirs': 'gallery',  # path to where to save gallery generated output
     'filename_pattern': '/*.py',
     'ignore_pattern': 'README.rst|/*_.py',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -191,7 +191,7 @@ def reset_napari_theme(gallery_conf, fname):
 
 
 sphinx_gallery_conf = {
-    'examples_dirs': 'napari/examples',  # path to your example scripts
+    'examples_dirs': '../examples',  # path to your example scripts
     'gallery_dirs': 'gallery',  # path to where to save gallery generated output
     'filename_pattern': '/*.py',
     'ignore_pattern': 'README.rst|/*_.py',


### PR DESCRIPTION
# Description
The build action appears to be failing, with an error related to the path of the examples:
```
Extension error:
[52](https://github.com/napari/docs/actions/runs/3254781307/jobs/5343418375#step:9:53)
Example directory /home/runner/work/docs/docs/docs/docs/../../napari/examples does not have a README file with one of the expected file extensions ['.txt', '.md', '.rst']. Please write one to introduce your gallery.
[53](https://github.com/napari/docs/actions/runs/3254781307/jobs/5343418375#step:9:54)
make: *** [Makefile:15: docs-build] Error 2
```

Edit: also the nesting is tricky, because the docs building on `napari/napari` will use this same `conf.py`. Hence doing the same copy step to ensure the paths are correct.

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/docs/dev/guides/translations.html).
