### PR TITLE
[Maint] fix build_and_deploy.yml paths

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: docs
+          name: html
           path: docs/docs/_build/html/
 
   deploy:
@@ -91,7 +91,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: docs
+          path: html
 
       - name: get directory name
         # if this is a tag, use the tag name as the directory name else dev
@@ -107,7 +107,7 @@ jobs:
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           external_repository: napari/napari.github.io
-          publish_dir: ./docs
+          publish_dir: html/
           publish_branch: gh-pages
           destination_dir: ${{ env.branch_name }}
           cname: napari.org


### PR DESCRIPTION
# References and relevant issues
The deploy workflow "works" but is deploying nothing:
https://github.com/napari/docs/actions/runs/8563891050/job/23469798992#step:4:1833
> cp: no such file or directory: /home/runner/work/docs/docs/docs/*

The artifact is extracted to:
https://github.com/napari/docs/actions/runs/8563891050/job/23469798992#step:2:12
> Starting download of artifact to: /home/runner/work/docs/docs

There is confusing paths with docs and docs. It looks like the deployment is relative to the last working dir and not the top-level.

# Description
In this PR I set the path of the download action to `html` (instead of downloading by name, which shouldn't matter here) which should make things clearer and then use that for the deployment.